### PR TITLE
Resize Month Events

### DIFF
--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -1,8 +1,8 @@
-import React from 'react'
-import events from '../events'
-import HTML5Backend from 'react-dnd-html5-backend'
-import { DragDropContext } from 'react-dnd'
-import BigCalendar from 'react-big-calendar'
+import React from 'react';
+import events from '../events';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { DragDropContext } from 'react-dnd';
+import BigCalendar from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
 
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.less';
@@ -10,13 +10,13 @@ import 'react-big-calendar/lib/addons/dragAndDrop/styles.less';
 const DragAndDropCalendar = withDragAndDrop(BigCalendar);
 
 class Dnd extends React.Component {
-  constructor (props) {
-    super(props)
+  constructor(props) {
+    super(props);
     this.state = {
-      events: events
-    }
+      events: events,
+    };
 
-    this.moveEvent = this.moveEvent.bind(this)
+    this.moveEvent = this.moveEvent.bind(this);
   }
 
   moveEvent({ event, start, end }) {
@@ -25,27 +25,56 @@ class Dnd extends React.Component {
     const idx = events.indexOf(event);
     const updatedEvent = { ...event, start, end };
 
-    const nextEvents = [...events]
-    nextEvents.splice(idx, 1, updatedEvent)
+    const nextEvents = [...events];
+    nextEvents.splice(idx, 1, updatedEvent);
 
     this.setState({
-      events: nextEvents
-    })
+      events: nextEvents,
+    });
 
     alert(`${event.title} was dropped onto ${event.start}`);
   }
 
-  render(){
+  handleEventResize = (resizeType, { event, start, end }) => {
+    const { events } = this.state;
+
+    // if we want to update the event while dragging we need to find the event
+    // by an identifier. here we use the title and the start time, but depending
+    // on use case you may want have a truly unique id attribute in the event
+
+    const nextEvents = events.map(existingEvent => {
+      return existingEvent.start == event.start && existingEvent.title == event.title
+        ? { ...existingEvent, start, end }
+        : existingEvent;
+    });
+
+    // if we only care about updating the event onDrop, we could rely on finding
+    // the event through Array.prototype.indexOf like in the moveEvent callback ie:
+    // if (resizeType !== 'drop') return;
+    // const idx = events.indexOf(event);
+    // const updatedEvent = { ...event, end };
+
+    // const nextEvents = [...events]
+    // nextEvents.splice(idx, 1, updatedEvent)
+
+    this.setState({
+      events: nextEvents,
+    });
+  };
+
+  render() {
     return (
       <DragAndDropCalendar
         selectable
         events={this.state.events}
         onEventDrop={this.moveEvent}
-        defaultView='week'
+        defaultView="month"
+        resizable
+        onEventResize={this.handleEventResize}
         defaultDate={new Date(2015, 3, 12)}
       />
-    )
+    );
   }
 }
 
-export default DragDropContext(HTML5Backend)(Dnd)
+export default DragDropContext(HTML5Backend)(Dnd);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
   "license": "MIT",
   "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",
-  "files": ["lib/", "LICENSE", "README.md", "CHANGELOG.md"],
+  "files": [
+    "lib/",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "keywords": [
     "scheduler",
     "react-component",
@@ -25,19 +30,14 @@
     "clean": "rimraf lib",
     "clean:examples": "rimraf examples/static",
     "l": "lessc --autoprefix=\"ie >= 10, safari >= 8, last 2 versions\" ",
-    "less":
-      "npm run l src/less/styles.less ./lib/css/react-big-calendar.css && npm run less-dnd",
-    "less-dnd":
-      "npm run l src/addons/dragAndDrop/styles.less ./lib/addons/dragAndDrop/styles.css",
+    "less": "npm run l src/less/styles.less ./lib/css/react-big-calendar.css && npm run less-dnd",
+    "less-dnd": "npm run l src/addons/dragAndDrop/styles.less ./lib/addons/dragAndDrop/styles.css",
     "assets": "cpy src/less/* lib/less && npm run assets-addons",
     "assets-addons": "cpy addons/**/*.less ../lib/ --cwd=src --parents",
-    "build":
-      "npm run clean && babel src --out-dir lib && npm run assets && npm run less && npm run less",
-    "build:examples":
-      "npm run clean:examples && webpack --config webpack/examples.config.js",
+    "build": "npm run clean && babel src --out-dir lib && npm run assets && npm run less && npm run less",
+    "build:examples": "npm run clean:examples && webpack --config webpack/examples.config.js",
     "build:visual-test": "webpack --config webpack/visual-test.js",
-    "examples":
-      "npm run clean:examples && webpack-dev-server --inline --hot --config webpack/examples.config.js",
+    "examples": "npm run clean:examples && webpack-dev-server --inline --hot --config webpack/examples.config.js",
     "lint": "eslint src --ext .jsx --ext .js",
     "storybook": "start-storybook -p 9002",
     "test": "npm run lint",
@@ -84,6 +84,7 @@
   "dependencies": {
     "classnames": "^2.1.3",
     "date-arithmetic": "^3.0.0",
+    "date-fns": "^1.28.5",
     "dom-helpers": "^2.3.0 || ^3.0.0",
     "invariant": "^2.1.0",
     "lodash": "^4.17.4",

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -655,6 +655,7 @@ class Calendar extends React.Component {
           onSelectSlot={this.handleSelectSlot}
           onShowMore={this._showMore}
           showAllEvents={this.props.showAllEvents}
+          resizable={this.props.resizable}
         />
       </div>
     );

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -47,56 +47,50 @@ const propTypes = {
 const defaultProps = {
   minRows: 0,
   maxRows: Infinity,
-}
+};
 
 class DateContentRow extends React.Component {
-
   constructor(...args) {
     super(...args);
   }
 
-  handleSelectSlot = (slot) => {
+  handleSelectSlot = slot => {
     const { range, onSelectSlot } = this.props;
 
-    onSelectSlot(
-      range.slice(slot.start, slot.end + 1),
-      slot,
-    )
-  }
+    onSelectSlot(range.slice(slot.start, slot.end + 1), slot);
+  };
 
-  handleShowMore = (slot) => {
+  handleShowMore = slot => {
     const { range, onShowMore } = this.props;
-    let row = qsa(findDOMNode(this), '.rbc-row-bg')[0]
+    let row = qsa(findDOMNode(this), '.rbc-row-bg')[0];
 
     let cell;
-    if (row) cell = row.children[slot-1]
+    if (row) cell = row.children[slot - 1];
 
-    let events = this.segments
-      .filter(seg => isSegmentInSlot(seg, slot))
-      .map(seg => seg.event)
+    let events = this.segments.filter(seg => isSegmentInSlot(seg, slot)).map(seg => seg.event);
 
-    onShowMore(events, range[slot-1], cell, slot)
-  }
+    onShowMore(events, range[slot - 1], cell, slot);
+  };
 
   createHeadingRef = r => {
     this.headingRow = r;
-  }
+  };
 
   createEventRef = r => {
     this.eventRow = r;
-  }
+  };
 
   getContainer = () => {
     const { container } = this.props;
-    return container ? container() : findDOMNode(this)
-  }
+    return container ? container() : findDOMNode(this);
+  };
 
   getRowLimit() {
     let eventHeight = getHeight(this.eventRow);
-    let headingHeight = this.headingRow ? getHeight(this.headingRow) : 0
+    let headingHeight = this.headingRow ? getHeight(this.headingRow) : 0;
     let eventSpace = getHeight(findDOMNode(this)) - headingHeight;
 
-    return Math.max(Math.floor(eventSpace / eventHeight), 1)
+    return Math.max(Math.floor(eventSpace / eventHeight), 1);
   }
 
   renderHeadingCell = (date, index) => {
@@ -109,31 +103,31 @@ class DateContentRow extends React.Component {
       className: cn(
         'rbc-date-cell',
         dates.eq(date, this.props.now, 'day') && 'rbc-now', // FIXME use props.now
-      )
-    })
-  }
+      ),
+    });
+  };
 
   renderDummy = () => {
     let { className, range, renderHeader } = this.props;
     return (
       <div className={className}>
-        <div className='rbc-row-content'>
+        <div className="rbc-row-content">
           {renderHeader && (
-            <div className='rbc-row' ref={this.createHeadingRef}>
+            <div className="rbc-row" ref={this.createHeadingRef}>
               {range.map(this.renderHeadingCell)}
             </div>
           )}
-          <div className='rbc-row' ref={this.createEventRef}>
-            <div className='rbc-row-segment' style={segStyle(1, range.length)}>
-              <div className='rbc-event'>
-                <div className='rbc-event-content'>&nbsp;</div>
+          <div className="rbc-row" ref={this.createEventRef}>
+            <div className="rbc-row-segment" style={segStyle(1, range.length)}>
+              <div className="rbc-event">
+                <div className="rbc-event-content">&nbsp;</div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    )
-  }
+    );
+  };
 
   render() {
     const {
@@ -147,7 +141,8 @@ class DateContentRow extends React.Component {
       startAccessor,
       endAccessor,
       renderHeader,
-      minRows, maxRows,
+      minRows,
+      maxRows,
       dateCellWrapper,
       eventComponent,
       eventWrapperComponent,
@@ -157,18 +152,25 @@ class DateContentRow extends React.Component {
       ...props
     } = this.props;
 
-    if (renderForMeasure)
-      return this.renderDummy();
+    if (renderForMeasure) return this.renderDummy();
 
     let { first, last } = endOfRange(range);
 
-    let segments = this.segments = events.map(evt => eventSegments(evt, first, last, {
-      startAccessor,
-      endAccessor
-    }, range))
+    let segments = (this.segments = events.map(evt =>
+      eventSegments(
+        evt,
+        first,
+        last,
+        {
+          startAccessor,
+          endAccessor,
+        },
+        range,
+      ),
+    ));
 
     let { levels, extra } = eventLevels(segments, Math.max(maxRows - 1, 1));
-    while (levels.length < minRows ) levels.push([])
+    while (levels.length < minRows) levels.push([]);
 
     return (
       <div className={className}>
@@ -185,13 +187,13 @@ class DateContentRow extends React.Component {
           longPressThreshold={longPressThreshold}
         />
 
-        <div className='rbc-row-content'>
+        <div className="rbc-row-content">
           {renderHeader && (
-            <div className='rbc-row' ref={this.createHeadingRef}>
+            <div className="rbc-row" ref={this.createHeadingRef}>
               {range.map(this.renderHeadingCell)}
             </div>
           )}
-          {levels.map((segs, idx) =>
+          {levels.map((segs, idx) => (
             <EventRow
               {...props}
               key={idx}
@@ -203,8 +205,9 @@ class DateContentRow extends React.Component {
               eventWrapperComponent={eventWrapperComponent}
               startAccessor={startAccessor}
               endAccessor={endAccessor}
+              resizable={this.props.resizable}
             />
-          )}
+          ))}
           {!!extra.length && (
             <EventEndingRow
               {...props}
@@ -225,4 +228,4 @@ class DateContentRow extends React.Component {
 DateContentRow.propTypes = propTypes;
 DateContentRow.defaultProps = defaultProps;
 
-export default DateContentRow
+export default DateContentRow;

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
+
 import dates from './utils/dates';
 import { accessor, elementType } from './utils/propTypes';
 import { accessor as get } from './utils/accessors';
+import ResizableMonthEvent from '../src/addons/dragAndDrop/ResizableMonthEvent';
 
 let propTypes = {
   event: PropTypes.object.isRequired,
@@ -20,53 +22,58 @@ let propTypes = {
   eventComponent: elementType,
   eventWrapperComponent: elementType.isRequired,
   onSelect: PropTypes.func,
-  onDoubleClick: PropTypes.func
-}
+  onDoubleClick: PropTypes.func,
+};
 
 class EventCell extends React.Component {
   render() {
     let {
-        className
-      , event
-      , selected
-      , eventPropGetter
-      , startAccessor, endAccessor, titleAccessor
-      , slotStart
-      , slotEnd
-      , onSelect
-      , onDoubleClick
-      , eventComponent: Event
-      , eventWrapperComponent: EventWrapper
-      , ...props } = this.props;
+      className,
+      endAccessor,
+      event,
+      eventComponent: Event,
+      eventPropGetter,
+      eventWrapperComponent: EventWrapper,
+      onDoubleClick,
+      onSelect,
+      resizable,
+      selected,
+      slotEnd,
+      slotStart,
+      startAccessor,
+      titleAccessor,
+      ...props
+    } = this.props;
 
-    let title = get(event, titleAccessor)
-      , end = get(event, endAccessor)
-      , start = get(event, startAccessor)
-      , isAllDay = get(event, props.allDayAccessor)
-      , continuesPrior = dates.lt(start, slotStart, 'day')
-      , continuesAfter = dates.gte(end, slotEnd, 'day')
+    let title = get(event, titleAccessor),
+      end = get(event, endAccessor),
+      start = get(event, startAccessor),
+      isAllDay = get(event, props.allDayAccessor),
+      continuesPrior = dates.lt(start, slotStart, 'day'),
+      continuesAfter = dates.gte(end, slotEnd, 'day');
 
     if (eventPropGetter)
       var { style, className: xClassName } = eventPropGetter(event, start, end, selected);
 
+    if (resizable) {
+      Event = ResizableMonthEvent;
+    }
+
     return (
       <EventWrapper event={event}>
         <div
-          style={{...props.style, ...style}}
+          style={{ ...props.style, ...style }}
           className={cn('rbc-event', className, xClassName, {
             'rbc-selected': selected,
             'rbc-event-allday': isAllDay || dates.diff(start, dates.ceil(end, 'day'), 'day') > 1,
             'rbc-event-continues-prior': continuesPrior,
-            'rbc-event-continues-after': continuesAfter
+            'rbc-event-continues-after': continuesAfter,
           })}
-          onClick={(e) => onSelect(event, e)}
-          onDoubleClick={(e) => onDoubleClick(event, e)}
+          onClick={e => onSelect(event, e)}
+          onDoubleClick={e => onDoubleClick(event, e)}
         >
-          <div className='rbc-event-content' title={title}>
-            { Event
-              ? <Event event={event} title={title}/>
-              : title
-            }
+          <div className="rbc-event-content" title={title}>
+            {Event ? <Event event={event} title={title} /> : title}
           </div>
         </div>
       </EventWrapper>
@@ -76,4 +83,4 @@ class EventCell extends React.Component {
 
 EventCell.propTypes = propTypes;
 
-export default EventCell
+export default EventCell;

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -24,23 +24,30 @@ export default {
     eventComponent: elementType,
     eventWrapperComponent: elementType.isRequired,
     onSelect: PropTypes.func,
-    onDoubleClick: PropTypes.func
+    onDoubleClick: PropTypes.func,
   },
 
   defaultProps: {
     segments: [],
     selected: {},
-    slots: 7
+    slots: 7,
   },
 
   renderEvent(props, event) {
     let {
-        eventPropGetter, selected, start, end
-      , startAccessor, endAccessor, titleAccessor
-      , allDayAccessor, eventComponent
-      , eventWrapperComponent
-      , onSelect
-      , onDoubleClick } = props;
+      eventPropGetter,
+      selected,
+      start,
+      end,
+      startAccessor,
+      endAccessor,
+      titleAccessor,
+      allDayAccessor,
+      eventComponent,
+      eventWrapperComponent,
+      onSelect,
+      onDoubleClick,
+    } = props;
 
     return (
       <EventCell
@@ -57,21 +64,22 @@ export default {
         slotStart={start}
         slotEnd={end}
         eventComponent={eventComponent}
+        resizable={props.resizable}
       />
-    )
+    );
   },
 
-  renderSpan(props, len, key, content = ' '){
+  renderSpan(props, len, key, content = ' ') {
     let { slots } = props;
 
     return (
-      <div key={key} className='rbc-row-segment' style={segStyle(Math.abs(len), slots)}>
+      <div key={key} className="rbc-row-segment" style={segStyle(Math.abs(len), slots)}>
         {content}
       </div>
-    )
+    );
   },
 
-  getRowHeight(){
-    getHeight(findDOMNode(this))
-  }
-}
+  getRowHeight() {
+    getHeight(findDOMNode(this));
+  },
+};

--- a/src/Month.js
+++ b/src/Month.js
@@ -204,6 +204,7 @@ class MonthView extends React.Component {
         eventWrapperComponent={components.eventWrapper}
         dateCellWrapper={components.dateCellWrapper}
         longPressThreshold={longPressThreshold}
+        resizable={this.props.resizable}
       />
     );
   };

--- a/src/addons/dragAndDrop/ResizableMonthEvent.js
+++ b/src/addons/dragAndDrop/ResizableMonthEvent.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { DragSource } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import compose from './compose';
+
+class ResizableMonthEvent extends React.Component {
+  componentDidMount() {
+    this.props.connectLeftDragPreview(getEmptyImage(), {
+      captureDraggingState: true,
+    });
+    this.props.connectRightDragPreview(getEmptyImage(), {
+      captureDraggingState: true,
+    });
+  }
+
+  render() {
+    const { title, connectLeftDragSource, connectRightDragSource } = this.props;
+    const [Left, Right] = [connectLeftDragSource, connectRightDragSource].map(connectDragSource => {
+      return connectDragSource(<div className="rbc-addons-dnd-resize-month-event-anchor"> </div>);
+    });
+    return (
+      <div className="rbc-addons-dnd-resizable-month-event">
+        {Left}
+        {title}
+        {Right}
+      </div>
+    );
+  }
+}
+
+const eventSourceLeft = {
+  beginDrag: ({ event }) => ({ ...event, type: 'resizeL' }),
+};
+
+const eventSourceRight = {
+  beginDrag: ({ event }) => ({ ...event, type: 'resizeR' }),
+};
+
+export default compose(
+  DragSource('resize', eventSourceLeft, (connect, monitor) => ({
+    connectLeftDragSource: connect.dragSource(),
+    connectLeftDragPreview: connect.dragPreview(),
+  })),
+  DragSource('resize', eventSourceRight, (connect, monitor) => ({
+    connectRightDragSource: connect.dragSource(),
+    connectRightDragPreview: connect.dragPreview(),
+  })),
+)(ResizableMonthEvent);

--- a/src/addons/dragAndDrop/backgroundWrapper.js
+++ b/src/addons/dragAndDrop/backgroundWrapper.js
@@ -1,35 +1,40 @@
-import PropTypes from 'prop-types';
-import React from 'react'
-import { DropTarget } from 'react-dnd'
+import React from 'react';
 import cn from 'classnames';
+import PropTypes from 'prop-types';
+import { DropTarget } from 'react-dnd';
+import addHours from 'date-fns/add_hours';
+import getHours from 'date-fns/get_hours';
+import addMinutes from 'date-fns/add_minutes';
+import getMinutes from 'date-fns/get_minutes';
+import addMilliseconds from 'date-fns/add_milliseconds';
 
+import compose from './compose';
+import dates from '../../utils/dates';
+import BigCalendar from '../../index';
 import { accessor } from '../../utils/propTypes';
 import { accessor as get } from '../../utils/accessors';
-import dates from '../../utils/dates';
-import BigCalendar from '../../index'
 
 export function getEventTimes(start, end, dropDate, type) {
   // Calculate duration between original start and end dates
-  const duration = dates.diff(start, end)
+  const duration = dates.diff(start, end);
 
   // If the event is dropped in a "Day" cell, preserve an event's start time by extracting the hours and minutes off
   // the original start date and add it to newDate.value
-  const nextStart = type === 'dateCellWrapper'
-    ? dates.merge(dropDate, start) : dropDate
+  const nextStart = type === 'dateCellWrapper' ? dates.merge(dropDate, start) : dropDate;
 
-  const nextEnd = dates.add(nextStart, duration, 'milliseconds')
+  const nextEnd = dates.add(nextStart, duration, 'milliseconds');
 
   return {
     start: nextStart,
-    end: nextEnd
-  }
+    end: nextEnd,
+  };
 }
 
 const propTypes = {
   connectDropTarget: PropTypes.func.isRequired,
   type: PropTypes.string,
   isOver: PropTypes.bool,
-}
+};
 
 class DraggableBackgroundWrapper extends React.Component {
   // constructor(...args) {
@@ -72,58 +77,94 @@ class DraggableBackgroundWrapper extends React.Component {
   //   }
   // };
 
+  componentWillReceiveProps(nextProps) {
+    const { isOver: wasOver } = this.props;
+    const { isOver } = nextProps;
+    if (isOver && !wasOver) {
+      const { onEventResize, dragDropManager } = this.context;
+      const { value } = this.props;
+      const monitor = dragDropManager.getMonitor();
+      if (monitor.getItemType() === 'resize') {
+        // This was causing me performance issues so I commented it out. Thoughts? - Adam Recvlohe Oct. 6 2017
+        // onEventResize('drag', {event: monitor.getItem(), end: value});
+      }
+    }
+  }
+
   render() {
     const { connectDropTarget, children, type, isOver } = this.props;
     const BackgroundWrapper = BigCalendar.components[type];
 
-    let resultingChildren = children
+    let resultingChildren = children;
     if (isOver)
       resultingChildren = React.cloneElement(children, {
-        className: cn(children.props.className, 'rbc-addons-dnd-over')
-      })
+        className: cn(children.props.className, 'rbc-addons-dnd-over'),
+      });
 
-    return (
-      <BackgroundWrapper>
-        {connectDropTarget(resultingChildren)}
-      </BackgroundWrapper>
-    );
+    return <BackgroundWrapper>{connectDropTarget(resultingChildren)}</BackgroundWrapper>;
   }
 }
 DraggableBackgroundWrapper.propTypes = propTypes;
 
 DraggableBackgroundWrapper.contextTypes = {
   onEventDrop: PropTypes.func,
+  onEventResize: PropTypes.func,
   dragDropManager: PropTypes.object,
   startAccessor: accessor,
-  endAccessor: accessor
-}
+  endAccessor: accessor,
+};
 
 function createWrapper(type) {
   function collectTarget(connect, monitor) {
     return {
       type,
       connectDropTarget: connect.dropTarget(),
-      isOver: monitor.isOver()
+      isOver: monitor.isOver(),
     };
   }
-
 
   const dropTarget = {
     drop(_, monitor, { props, context }) {
       const event = monitor.getItem();
-      const { value } = props
-      const { onEventDrop, startAccessor, endAccessor } = context
+      const { value } = props;
+      const { onEventDrop, onEventResize, startAccessor, endAccessor } = context;
       const start = get(event, startAccessor);
       const end = get(event, endAccessor);
 
-      onEventDrop({
-        event,
-        ...getEventTimes(start, end, value, type)
-      })
-    }
+      if (monitor.getItemType() === 'event') {
+        onEventDrop({
+          event,
+          ...getEventTimes(start, end, value, type),
+        });
+      }
+
+      if (monitor.getItemType() === 'resize') {
+        switch (event.type) {
+          case 'resizeL': {
+            return onEventResize('drop', { event, start: value, end: event.end });
+          }
+          case 'resizeR': {
+            const [hrs, mins] = [getHours(event.end), getMinutes(event.end)];
+            const nextEnd = compose(
+              v => addHours(v, hrs),
+              v => addMinutes(v, mins),
+              v => (hrs === 0 && mins === 0 ? addMilliseconds(v, 1) : value),
+            )(value);
+            return onEventResize('drop', { event, start: event.start, end: nextEnd });
+          }
+        }
+
+        // Catch All
+        onEventResize('drop', {
+          event,
+          start: event.start,
+          end: value,
+        });
+      }
+    },
   };
 
-  return DropTarget(['event'], dropTarget, collectTarget)(DraggableBackgroundWrapper);
+  return DropTarget(['event', 'resize'], dropTarget, collectTarget)(DraggableBackgroundWrapper);
 }
 
 export const DateCellWrapper = createWrapper('dateCellWrapper');

--- a/src/addons/dragAndDrop/compose.js
+++ b/src/addons/dragAndDrop/compose.js
@@ -1,0 +1,11 @@
+export default function compose(...funcs) {
+  if (funcs.length === 0) {
+    return arg => arg;
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+
+  return funcs.reduce((a, b) => (...args) => a(b(...args)));
+}

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -1,34 +1,33 @@
 import PropTypes from 'prop-types';
-import React from 'react'
-import { DragDropContext } from 'react-dnd'
+import React from 'react';
+import { DragDropContext } from 'react-dnd';
 import cn from 'classnames';
 
 import { accessor } from '../../utils/propTypes';
-import DraggableEventWrapper from './DraggableEventWrapper'
-import { DayWrapper, DateCellWrapper } from './backgroundWrapper'
+import DraggableEventWrapper from './DraggableEventWrapper';
+import { DayWrapper, DateCellWrapper } from './backgroundWrapper';
 
 let html5Backend;
 
 try {
-  html5Backend = require('react-dnd-html5-backend')
-} catch (err) { /* optional dep missing */}
+  html5Backend = require('react-dnd-html5-backend');
+} catch (err) {
+  /* optional dep missing */
+}
 
-
-export default function withDragAndDrop(Calendar, {
-  backend = html5Backend
-} = {}) {
-
+export default function withDragAndDrop(Calendar, { backend = html5Backend } = {}) {
   class DragAndDropCalendar extends React.Component {
     static propTypes = {
       selectable: PropTypes.oneOf([true, false, 'ignoreEvents']).isRequired,
       components: PropTypes.object,
-    }
-    getChildContext () {
+    };
+    getChildContext() {
       return {
         onEventDrop: this.props.onEventDrop,
+        onEventResize: this.props.onEventResize,
         startAccessor: this.props.startAccessor,
-        endAccessor: this.props.endAccessor
-      }
+        endAccessor: this.props.endAccessor,
+      };
     }
 
     constructor(...args) {
@@ -37,15 +36,14 @@ export default function withDragAndDrop(Calendar, {
     }
 
     componentWillMount() {
-      let monitor = this.context.dragDropManager.getMonitor()
-      this.monitor = monitor
-      this.unsubscribeToStateChange = monitor
-        .subscribeToStateChange(this.handleStateChange)
+      let monitor = this.context.dragDropManager.getMonitor();
+      this.monitor = monitor;
+      this.unsubscribeToStateChange = monitor.subscribeToStateChange(this.handleStateChange);
     }
 
     componentWillUnmount() {
-      this.monitor = null
-      this.unsubscribeToStateChange()
+      this.monitor = null;
+      this.unsubscribeToStateChange();
     }
 
     handleStateChange = () => {
@@ -54,53 +52,56 @@ export default function withDragAndDrop(Calendar, {
       if (isDragging !== this.state.isDragging) {
         setTimeout(() => this.setState({ isDragging }));
       }
-    }
+    };
 
     render() {
       const { selectable, components, ...props } = this.props;
 
       delete props.onEventDrop;
+      delete props.onEventResize;
 
-      props.selectable = selectable
-        ? 'ignoreEvents' : false;
+      props.selectable = selectable ? 'ignoreEvents' : false;
 
       props.className = cn(
         props.className,
         'rbc-addons-dnd',
-        this.state.isDragging && 'rbc-addons-dnd-is-dragging'
-      )
+        this.state.isDragging && 'rbc-addons-dnd-is-dragging',
+      );
 
       props.components = {
         ...components,
         eventWrapper: DraggableEventWrapper,
         dateCellWrapper: DateCellWrapper,
-        dayWrapper: DayWrapper
-      }
+        dayWrapper: DayWrapper,
+      };
 
-      return <Calendar {...props} />
+      return <Calendar {...props} />;
     }
   }
 
   DragAndDropCalendar.propTypes = {
+    endAccessor: accessor,
     onEventDrop: PropTypes.func.isRequired,
+    onEventResize: PropTypes.func,
+    resizable: PropTypes.bool,
     startAccessor: accessor,
-    endAccessor: accessor
-  }
+  };
 
   DragAndDropCalendar.defaultProps = {
     startAccessor: 'start',
-    endAccessor: 'end'
+    endAccessor: 'end',
   };
 
   DragAndDropCalendar.contextTypes = {
-    dragDropManager: PropTypes.object
-  }
+    dragDropManager: PropTypes.object,
+  };
 
   DragAndDropCalendar.childContextTypes = {
+    endAccessor: accessor,
     onEventDrop: PropTypes.func,
+    onEventResize: PropTypes.func,
     startAccessor: accessor,
-    endAccessor: accessor
-  }
+  };
 
   if (backend === false) {
     return DragAndDropCalendar;

--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -15,7 +15,7 @@
       red(@date-selection-bg-color),
       green(@date-selection-bg-color),
       blue(@date-selection-bg-color),
-      .3
+      0.3
     );
   }
 
@@ -26,7 +26,28 @@
 
   &.rbc-addons-dnd-is-dragging .rbc-event {
     pointer-events: none;
-    opacity: .50;
+    opacity: 0.5;
+  }
+
+  .rbc-addons-dnd-resizable-month-event {
+    position: relative;
+    /* user-drag: none; */
+    .rbc-addons-dnd-resize-month-event-anchor {
+      width: 20px;
+      height: 20px;
+      top: 0;
+      &:hover {
+        cursor: ew-resize;
+      }
+      &:first-child {
+        position: absolute;
+        left: -5px;
+      }
+      &:last-child {
+        position: absolute;
+        right: -5px;
+      }
+    }
   }
 
   // .rbc-addons-dnd-dragging {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5201,13 +5201,8 @@ react-overlays@^0.6.0:
     warning "^3.0.0"
 
 react-overlays@^0.7.0:
-<<<<<<< HEAD
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.1.tgz#0b84708d8007082163c47155a2f60a0858c7a3c7"
-=======
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.2.tgz#03808f80d99dfadd93d67438c619aa55d07b3f80"
->>>>>>> Add date-fns Package
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,6 +2280,10 @@ date-arithmetic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-arithmetic/-/date-arithmetic-3.1.0.tgz#1fcd03dbd504b9dbee2b9078c85a5f1c7d3cc2d3"
 
+date-fns@^1.28.5:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -5197,8 +5201,13 @@ react-overlays@^0.6.0:
     warning "^3.0.0"
 
 react-overlays@^0.7.0:
+<<<<<<< HEAD
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.1.tgz#0b84708d8007082163c47155a2f60a0858c7a3c7"
+=======
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.2.tgz#03808f80d99dfadd93d67438c619aa55d07b3f80"
+>>>>>>> Add date-fns Package
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"


### PR DESCRIPTION
## Description
This PR adds the ability to resize month events by clicking and dragging on the ends of an event.

Other code formatting changes were made with the help of prettier.

## Screenshots

![resize-month-events](https://user-images.githubusercontent.com/9747933/31290190-89e5d240-aa99-11e7-9023-7d2595edbed1.gif)
