### PR TITLE
Add rename-events-inline feature

### DIFF
--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -5,6 +5,10 @@ import events from '../events';
 let allViews = Object.keys(BigCalendar.Views).map(k => BigCalendar.Views[k]);
 
 let Basic = React.createClass({
+  handleInlineEditEventTitle(title) {
+    console.log(title);
+  },
+
   render() {
     return (
       <BigCalendar
@@ -14,6 +18,7 @@ let Basic = React.createClass({
         showAllEvents
         step={60}
         views={allViews}
+        onInlineEditEventTitle={this.handleInlineEditEventTitle}
       />
     );
   },

--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -5,10 +5,6 @@ import events from '../events';
 let allViews = Object.keys(BigCalendar.Views).map(k => BigCalendar.Views[k]);
 
 let Basic = React.createClass({
-  handleInlineEditEventTitle(title) {
-    console.log(title);
-  },
-
   render() {
     return (
       <BigCalendar
@@ -18,7 +14,6 @@ let Basic = React.createClass({
         showAllEvents
         step={60}
         views={allViews}
-        onInlineEditEventTitle={this.handleInlineEditEventTitle}
       />
     );
   },

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -19,6 +19,10 @@ class Dnd extends React.Component {
     this.moveEvent = this.moveEvent.bind(this);
   }
 
+  handleInlineEditEventTitle = title => {
+    console.log(title);
+  };
+
   moveEvent({ event, start, end }) {
     const { events } = this.state;
 
@@ -72,6 +76,7 @@ class Dnd extends React.Component {
         resizable
         onEventResize={this.handleEventResize}
         defaultDate={new Date(2015, 3, 12)}
+        onInlineEditEventTitle={this.handleInlineEditEventTitle}
       />
     );
   }

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -20,7 +20,7 @@ class Dnd extends React.Component {
   }
 
   handleInlineEditEventTitle = title => {
-    console.log(title);
+    alert(title);
   };
 
   moveEvent({ event, start, end }) {

--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -3,28 +3,29 @@ import BigCalendar from 'react-big-calendar';
 import events from '../events';
 
 let Selectable = React.createClass({
-  render(){
+  render() {
     return (
       <div {...this.props}>
         <h3 className="callout">
-          Click an event to see more info, or
-          drag the mouse over the calendar to select a date/time range.
+          Click an event to see more info, or drag the mouse over the calendar to select a date/time
+          range.
         </h3>
         <BigCalendar
           selectable
           events={events}
-          defaultView='week'
+          defaultView="week"
           scrollToTime={new Date(1970, 1, 1, 6)}
           defaultDate={new Date(2015, 3, 12)}
           onSelectEvent={event => alert(event.title)}
-          onSelectSlot={(slotInfo) => alert(
-            `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
-            `\nend: ${slotInfo.end.toLocaleString()}`
-          )}
+          onSelectSlot={slotInfo =>
+            alert(
+              `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
+                `\nend: ${slotInfo.end.toLocaleString()}`,
+            )}
         />
       </div>
-    )
-  }
-})
+    );
+  },
+});
 
 export default Selectable;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "react-big-calendar",
-  "version": "0.16.1",
+  "name": "citrusbyte-calendar",
+  "version": "1.0.0",
   "description": "React Calendar",
   "contributors": ["Adam Recvlohe <adam.recvlohe@citrusbyte.com>"],
-  "repository": "citrusbyte/react-big-calendar",
+  "repository": "https://github.com/citrusbyte/react-big-calendar",
   "license": "MIT",
   "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",

--- a/package.json
+++ b/package.json
@@ -1,26 +1,14 @@
 {
   "name": "react-big-calendar",
   "version": "0.16.1",
-  "description": "Calendar! with events",
-  "author": "Jason Quense <monastic.panic@gmail.com>",
-  "repository": "intljusticemission/react-big-calendar",
+  "description": "React Calendar",
+  "contributors": ["Adam Recvlohe <adam.recvlohe@citrusbyte.com>"],
+  "repository": "citrusbyte/react-big-calendar",
   "license": "MIT",
   "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",
-  "files": [
-    "lib/",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md"
-  ],
-  "keywords": [
-    "scheduler",
-    "react-component",
-    "react",
-    "calendar",
-    "events",
-    "full calendar"
-  ],
+  "files": ["lib/", "LICENSE", "README.md", "CHANGELOG.md"],
+  "keywords": ["scheduler", "react-component", "react", "calendar", "events", "full calendar"],
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,
@@ -34,10 +22,12 @@
     "less-dnd": "npm run l src/addons/dragAndDrop/styles.less ./lib/addons/dragAndDrop/styles.css",
     "assets": "cpy src/less/* lib/less && npm run assets-addons",
     "assets-addons": "cpy addons/**/*.less ../lib/ --cwd=src --parents",
-    "build": "npm run clean && babel src --out-dir lib && npm run assets && npm run less && npm run less",
+    "build":
+      "npm run clean && babel src --out-dir lib && npm run assets && npm run less && npm run less",
     "build:examples": "npm run clean:examples && webpack --config webpack/examples.config.js",
     "build:visual-test": "webpack --config webpack/visual-test.js",
-    "examples": "npm run clean:examples && webpack-dev-server --inline --hot --config webpack/examples.config.js",
+    "examples":
+      "npm run clean:examples && webpack-dev-server --inline --hot --config webpack/examples.config.js",
     "lint": "eslint src --ext .jsx --ext .js",
     "storybook": "start-storybook -p 9002",
     "test": "npm run lint",

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -656,6 +656,7 @@ class Calendar extends React.Component {
           onShowMore={this._showMore}
           showAllEvents={this.props.showAllEvents}
           resizable={this.props.resizable}
+          onInlineEditEventTitle={this.props.onInlineEditEventTitle}
         />
       </div>
     );

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -206,6 +206,7 @@ class DateContentRow extends React.Component {
               startAccessor={startAccessor}
               endAccessor={endAccessor}
               resizable={this.props.resizable}
+              onInlineEditEventTitle={this.props.onInlineEditEventTitle}
             />
           ))}
           {!!extra.length && (

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -47,7 +47,12 @@ class EventCell extends React.Component {
     const { onInlineEditEventTitle } = this.props;
     if (e.key == 'Enter') {
       onInlineEditEventTitle(this.state.title);
+      this.setState({ isEditingEventTitle: false });
     }
+  };
+
+  handleBlur = () => {
+    this.setState({ isEditingEventTitle: false });
   };
 
   render() {
@@ -94,9 +99,9 @@ class EventCell extends React.Component {
             'rbc-event-continues-prior': continuesPrior,
             'rbc-event-continues-after': continuesAfter,
           })}
-          /* onClick={e => onSelect(event, e)} */
-          onClick={this.handleEditing}
-          onDoubleClick={e => onDoubleClick(event, e)}
+          onClick={e => onSelect(event, e)}
+          /*onDoubleClick={e => onDoubleClick(event, e)}*/
+          onDoubleClick={this.handleEditing}
         >
           <div className="rbc-event-content" title={title}>
             {Event && !this.state.isEditingEventTitle ? (
@@ -108,6 +113,7 @@ class EventCell extends React.Component {
                 value={this.state.title}
                 onChange={this.handleChange}
                 onKeyPress={this.handleKeyPress}
+                onBlur={this.handleBlur}
               />
             ) : (
               title
@@ -120,5 +126,9 @@ class EventCell extends React.Component {
 }
 
 EventCell.propTypes = propTypes;
+
+EventCell.defaultProps = {
+  onInlineEditEventTitle: () => {},
+};
 
 export default EventCell;

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -35,6 +35,15 @@ class EventCell extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    const { event, titleAccessor } = this.props;
+    const { event: nextEvent } = nextProps;
+    const [eventTitle, nextEventTitle] = [get(event, titleAccessor), get(nextEvent, titleAccessor)];
+    if (eventTitle !== nextEventTitle) {
+      this.setState({ title: nextEventTitle });
+    }
+  }
+
   handleEditing = () => {
     this.setState({ isEditingEventTitle: true });
   };

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -23,9 +23,33 @@ let propTypes = {
   eventWrapperComponent: elementType.isRequired,
   onSelect: PropTypes.func,
   onDoubleClick: PropTypes.func,
+  onInlineEditEventTitle: PropTypes.func.isRequired,
 };
 
 class EventCell extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isEditingEventTitle: false,
+      title: get(props.event, props.titleAccessor),
+    };
+  }
+
+  handleEditing = () => {
+    this.setState({ isEditingEventTitle: true });
+  };
+
+  handleChange = ({ target: { value } }) => {
+    this.setState({ title: value });
+  };
+
+  handleKeyPress = e => {
+    const { onInlineEditEventTitle } = this.props;
+    if (e.key == 'Enter') {
+      onInlineEditEventTitle(this.state.title);
+    }
+  };
+
   render() {
     let {
       className,
@@ -42,6 +66,7 @@ class EventCell extends React.Component {
       slotStart,
       startAccessor,
       titleAccessor,
+      onInlineEditEventTitle,
       ...props
     } = this.props;
 
@@ -69,11 +94,24 @@ class EventCell extends React.Component {
             'rbc-event-continues-prior': continuesPrior,
             'rbc-event-continues-after': continuesAfter,
           })}
-          onClick={e => onSelect(event, e)}
+          /* onClick={e => onSelect(event, e)} */
+          onClick={this.handleEditing}
           onDoubleClick={e => onDoubleClick(event, e)}
         >
           <div className="rbc-event-content" title={title}>
-            {Event ? <Event event={event} title={title} /> : title}
+            {Event && !this.state.isEditingEventTitle ? (
+              <Event event={event} title={title} />
+            ) : this.state.isEditingEventTitle ? (
+              <input
+                type="text"
+                style={{ color: 'black' }}
+                value={this.state.title}
+                onChange={this.handleChange}
+                onKeyPress={this.handleKeyPress}
+              />
+            ) : (
+              title
+            )}
           </div>
         </div>
       </EventWrapper>

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -47,6 +47,7 @@ export default {
       eventWrapperComponent,
       onSelect,
       onDoubleClick,
+      onInlineEditEventTitle,
     } = props;
 
     return (
@@ -65,6 +66,7 @@ export default {
         slotEnd={end}
         eventComponent={eventComponent}
         resizable={props.resizable}
+        onInlineEditEventTitle={onInlineEditEventTitle}
       />
     );
   },

--- a/src/Month.js
+++ b/src/Month.js
@@ -205,6 +205,7 @@ class MonthView extends React.Component {
         dateCellWrapper={components.dateCellWrapper}
         longPressThreshold={longPressThreshold}
         resizable={this.props.resizable}
+        onInlineEditEventTitle={this.props.onInlineEditEventTitle}
       />
     );
   };


### PR DESCRIPTION
## Description
This PR adds the ability to rename the event title inline in the calendar when the event title is double clicked. The event title goes back to its normal state after an enter or blur action.

## Screenshots
![rename-event-inline](https://user-images.githubusercontent.com/9747933/31341852-dcd4599a-acd8-11e7-8961-9f6d218b64fd.gif)
