### PR TITLE
Add toolbar extras capability

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -219,6 +219,11 @@ class Calendar extends React.Component {
     toolbar: PropTypes.bool,
 
     /**
+     * React component to be rendered at the right of the toolbar
+     */
+    toolbarExtras: PropTypes.element,
+
+    /**
      * Show truncated events in an overlay when you click the "+_x_ more" link.
      */
     popup: PropTypes.bool,
@@ -599,6 +604,7 @@ class Calendar extends React.Component {
       style,
       className,
       elementProps,
+      toolbarExtras,
       date: current,
       ...props
     } = this.props;
@@ -635,6 +641,7 @@ class Calendar extends React.Component {
             onViewChange={this.handleViewChange}
             onNavigate={this.handleNavigate}
             messages={messages}
+            toolbarExtras={toolbarExtras}
           />
         )}
         <View

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -33,6 +33,10 @@ class Toolbar extends React.Component {
         <span className="rbc-toolbar-label">{label}</span>
 
         <span className="rbc-btn-group">{this.viewNamesGroup(messages)}</span>
+
+        {this.props.toolbarExtras && (
+          <div className="rbc-btn-group">{this.props.toolbarExtras}</div>
+        )}
       </div>
     );
   }

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -140,6 +140,28 @@ storiesOf('module.Calendar.week', module)
       </div>
     );
   })
+  .add('toolbar extras', () => {
+    return (
+      <div style={{ height: 600 }}>
+        <Calendar
+          defaultView="month"
+          views={['month']}
+          min={moment('12:00am', 'h:mma').toDate()}
+          max={moment('11:59pm', 'h:mma').toDate()}
+          events={events}
+          onSelectEvent={action('event selected')}
+          onSelectSlot={action('slot selected')}
+          defaultDate={new Date()}
+          toolbarExtras={
+            <div>
+              <button style={{ marginRight: '10px' }}>Extra</button>
+              <button>Buttons</button>
+            </div>
+          }
+        />
+      </div>
+    );
+  })
   .add('selectable', () => {
     return (
       <div style={{ height: 600 }}>


### PR DESCRIPTION
## Description
This PR adds support for adding a custom element on the toolbar via the new `toolbarExtras` prop.

## Screenshot
![image](https://user-images.githubusercontent.com/7253814/31457825-61360b2c-ae94-11e7-8d48-649d6742a065.png)