### PR TITLE
Remove Rambda, Add Ramda

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "invariant": "^2.1.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.8",
-    "rambda": "^0.9.6",
+    "ramda": "^0.25.0",
     "react-contextmenu": "^2.8.0",
     "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
 import styled from 'styled-components';
-import prop from 'rambda/modules/prop';
+import prop from 'ramda/src/prop';
 
 import dates from './utils/dates';
 import { accessor, elementType } from './utils/propTypes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,9 +5916,9 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-rambda@^0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/rambda/-/rambda-0.9.6.tgz#3c252d1d4dd524ae8eb9a6c76038655f4e6624bf"
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
 
 randomatic@^1.1.3:
   version "1.1.7"


### PR DESCRIPTION
Summary: Using Rambda is failing the CRA production build because rambda fails to minify:

https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify.

This is based on this build:

https://circleci.com/gh/citrusbyte/itv-calendar/543