### PR TITLE
Expose sort func via Cal prop

### DIFF
--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -107,6 +107,10 @@ class Dnd extends React.Component {
     console.log(`clicked menu item ${item} w/ event title: ${event.title}`);
   }
 
+  eventsSorter = (a, b) => {
+    return 0; // disable sort
+  };
+
   render() {
     return (
       <div>
@@ -116,6 +120,7 @@ class Dnd extends React.Component {
           defaultDate={new Date(2015, 3, 12)}
           defaultView="month"
           events={this.state.events}
+          eventsSorter={this.eventsSorter}
           onEventDrop={this.moveEvent}
           onEventResize={this.handleEventResize}
           onInlineEditEventTitle={this.handleInlineEditEventTitle}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -561,6 +561,8 @@ class Calendar extends React.Component {
      * Object should contain: label [string], onClick [func], data [obj] props
      */
     contextMenuItems: PropTypes.func,
+
+    eventsSorter: PropTypes.func,
   };
 
   static defaultProps = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -167,12 +167,16 @@ class MonthView extends React.Component {
       now,
       date,
       longPressThreshold,
+      eventsSorter,
     } = this.props;
 
     const { needLimitMeasure, rowLimit } = this.state;
 
     events = eventsForWeek(events, week[0], week[week.length - 1], this.props);
-    events.sort((a, b) => sortEvents(a, b, this.props));
+    events.sort((a, b) => {
+      let fn = eventsSorter || sortEvents;
+      return fn(a, b, this.props);
+    });
 
     return (
       <DateContentRow


### PR DESCRIPTION
We would like to allow the user access to how items are listed in a given `DateContentRow` and to do so we must expose the sort func via a prop.