### PR TITLE
Fix Bugs

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -64,7 +64,11 @@ class BackgroundCells extends React.Component {
                 className="rbc-day-bg-wrapper"
                 style={{ ...segStyle(1, range.length), height: '100%' }}
               >
-                <ContextMenuTrigger id="contextMenu" collect={props => ({ ...props, date })}>
+                <ContextMenuTrigger
+                  collect={props => ({ ...props, date })}
+                  holdToDisplay={-1}
+                  id="contextMenu"
+                >
                   <div
                     style={{ height: '100%' }}
                     className={cn('rbc-day-bg', {

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -148,7 +148,7 @@ class EventCell extends React.Component {
                   if (!currentTarget.contains(document.activeElement)) {
                     onSelect({}, e);
                   }
-                }, 0);
+                });
               }}
               onClick={e => onSelect(event, e)}
               /*onDoubleClick={e => onDoubleClick(event, e)}*/

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -132,6 +132,7 @@ class EventCell extends React.Component {
             id="rightClickEventContextMenu"
           >
             <div
+              tabIndex="-1"
               style={{ ...props.style, ...style }}
               className={cn('rbc-event', className, xClassName, {
                 'rbc-selected': selected,
@@ -140,6 +141,15 @@ class EventCell extends React.Component {
                 'rbc-event-continues-prior': continuesPrior,
                 'rbc-event-continues-after': continuesAfter,
               })}
+              onBlur={e => {
+                // https://gist.github.com/pstoica/4323d3e6e37e8a23dd59 - AR Mon Oct 23 10:35:26 EDT 2017
+                const currentTarget = e.currentTarget;
+                setTimeout(() => {
+                  if (!currentTarget.contains(document.activeElement)) {
+                    onSelect({}, e);
+                  }
+                }, 0);
+              }}
               onClick={e => onSelect(event, e)}
               /*onDoubleClick={e => onDoubleClick(event, e)}*/
               onDoubleClick={this.handleEditing}

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -128,6 +128,7 @@ class EventCell extends React.Component {
         <div>
           <ContextMenuTrigger
             collect={props => ({ ...props, event })}
+            holdToDisplay={-1}
             id="rightClickEventContextMenu"
           >
             <div


### PR DESCRIPTION
## Description
This PR fixes two bugs that are effecting UI in itv-calendar. The first bug is that the react-contextmenu opens when holding down on an event/day cell. The `holdToDisplay={-1}` removes this problem. The second bug is when blurring an event, the event remains selected. Making the event focusable and then adding an `onBlur` action resolves this problem.