### PR TITLE
Abstract Away Components for ContextMenu and ResizableMonthEvent

### DIFF
--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -101,7 +101,7 @@ class Dnd extends React.Component {
     return 0; // disable sort
   };
 
-  componentRightClickEventMenu = props => {
+  rightClickEventMenu = props => {
     const { id, trigger, handleClick } = props;
     const handleItemClick = trigger ? trigger.onItemClick : null;
     return (
@@ -124,7 +124,9 @@ class Dnd extends React.Component {
     return (
       <div>
         <DragAndDropCalendar
-          componentRightClickEventMenu={this.componentRightClickEventMenu}
+          contextMenuComponents={{
+            event: this.rightClickEventMenu,
+          }}
           components={{ month: { event: ResizableMonthEvent } }}
           contextMenuItems={this.contextMenuItems}
           defaultDate={new Date(2015, 3, 12)}

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -6,6 +6,8 @@ import BigCalendar from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
 import { ContextMenu, MenuItem } from 'react-contextmenu';
 
+import ResizableMonthEvent from '../../src/addons/dragAndDrop/ResizableMonthEvent';
+
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.less';
 
 const DragAndDropCalendar = withDragAndDrop(BigCalendar);
@@ -123,6 +125,7 @@ class Dnd extends React.Component {
       <div>
         <DragAndDropCalendar
           componentRightClickEventMenu={this.componentRightClickEventMenu}
+          components={{ month: { event: ResizableMonthEvent } }}
           contextMenuItems={this.contextMenuItems}
           defaultDate={new Date(2015, 3, 12)}
           defaultView="month"
@@ -132,7 +135,6 @@ class Dnd extends React.Component {
           onEventResize={this.handleEventResize}
           onInlineEditEventTitle={this.handleInlineEditEventTitle}
           onRightClickSlot={this.handleRightClickSlot}
-          resizable
           selectable
           showAllEvents
         />

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -4,6 +4,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
 import BigCalendar from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import { ContextMenu, MenuItem } from 'react-contextmenu';
 
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.less';
 
@@ -90,19 +91,6 @@ class Dnd extends React.Component {
     },
   ];
 
-  contextMenuItemsForRightClickEvent = [
-    {
-      label: 'Edit',
-      data: { item: 1 },
-      onClick: (e, props) => this.logMenuItemClickForEvent(props),
-    },
-    {
-      label: 'Lock',
-      data: { item: 2 },
-      onClick: (e, props) => this.logMenuItemClickForEvent(props),
-    },
-  ];
-
   logMenuItemClickForEvent({ item, event }) {
     console.log(`clicked menu item ${item} w/ event title: ${event.title}`);
   }
@@ -111,12 +99,31 @@ class Dnd extends React.Component {
     return 0; // disable sort
   };
 
+  componentRightClickEventMenu = props => {
+    const { id, trigger, handleClick } = props;
+    const handleItemClick = trigger ? trigger.onItemClick : null;
+    return (
+      <ContextMenu id={id}>
+        {trigger && (
+          <MenuItem onClick={(_, props) => console.log(props)} data={{ action: 'EDIT' }}>
+            Edit
+          </MenuItem>
+        )}
+        {trigger && (
+          <MenuItem onClick={(_, props) => console.log(props)} data={{ action: 'LOCK' }}>
+            {trigger.event.locked ? 'Unlock' : 'Lock'}
+          </MenuItem>
+        )}
+      </ContextMenu>
+    );
+  };
+
   render() {
     return (
       <div>
         <DragAndDropCalendar
+          componentRightClickEventMenu={this.componentRightClickEventMenu}
           contextMenuItems={this.contextMenuItems}
-          contextMenuItemsForRightClickEvent={this.contextMenuItemsForRightClickEvent}
           defaultDate={new Date(2015, 3, 12)}
           defaultView="month"
           events={this.state.events}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -718,7 +718,6 @@ class Calendar extends React.Component {
           onSelectSlot={this.handleSelectSlot}
           onShowMore={this._showMore}
           ref="view"
-          resizable={this.props.resizable}
           showAllEvents={this.props.showAllEvents}
         />
         {this.renderContextMenu()}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -638,7 +638,7 @@ class Calendar extends React.Component {
   };
 
   renderRightClickEventMenu() {
-    const { componentRightClickEventMenu: ContextMenu } = this.props;
+    const { contextMenuComponents: { event: ContextMenu } } = this.props;
 
     if (!ContextMenu) return null;
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -25,7 +25,8 @@ import defaults from 'lodash/defaults';
 import transform from 'lodash/transform';
 import mapValues from 'lodash/mapValues';
 
-import { ContextMenu, MenuItem } from 'react-contextmenu';
+import { ContextMenu, MenuItem, connectMenu } from 'react-contextmenu';
+import { RIGHT_CLICK_EVENT } from './ContextMenuTypes';
 
 function viewNames(_views) {
   return !Array.isArray(_views) ? Object.keys(_views) : _views;
@@ -636,22 +637,14 @@ class Calendar extends React.Component {
     );
   };
 
-  renderContextMenuForRightClickEvent() {
-    const { contextMenuItemsForRightClickEvent: menuItems } = this.props;
+  renderRightClickEventMenu() {
+    const { componentRightClickEventMenu: ContextMenu } = this.props;
 
-    if (!menuItems) return null;
+    if (!ContextMenu) return null;
 
-    return (
-      <ContextMenu id="rightClickEventContextMenu">
-        {menuItems.map(({ onClick, data, label }, i) => {
-          return (
-            <MenuItem key={`rightClickEventContextMenu${i}`} onClick={onClick} data={data}>
-              {label}
-            </MenuItem>
-          );
-        })}
-      </ContextMenu>
-    );
+    const ConnectedMenu = connectMenu(RIGHT_CLICK_EVENT)(ContextMenu);
+
+    return <ConnectedMenu />;
   }
 
   render() {
@@ -729,7 +722,7 @@ class Calendar extends React.Component {
           showAllEvents={this.props.showAllEvents}
         />
         {this.renderContextMenu()}
-        {this.renderContextMenuForRightClickEvent()}
+        {this.renderRightClickEventMenu()}
       </div>
     );
   }

--- a/src/ContextMenuTypes.js
+++ b/src/ContextMenuTypes.js
@@ -1,0 +1,3 @@
+export default {
+  RIGHT_CLICK_EVENT: 'RIGHT_CLICK_EVENT',
+};

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -210,7 +210,6 @@ class DateContentRow extends React.Component {
               eventWrapperComponent={eventWrapperComponent}
               key={idx}
               onInlineEditEventTitle={this.props.onInlineEditEventTitle}
-              resizable={this.props.resizable}
               segments={segs}
               slots={range.length}
               start={first}

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -8,26 +8,23 @@ import { ContextMenuTrigger } from 'react-contextmenu';
 import dates from './utils/dates';
 import { accessor, elementType } from './utils/propTypes';
 import { accessor as get } from './utils/accessors';
-import ResizableMonthEvent from './addons/dragAndDrop/ResizableMonthEvent';
 import { RIGHT_CLICK_EVENT } from './ContextMenuTypes';
 
 let propTypes = {
-  event: PropTypes.object.isRequired,
-  slotStart: PropTypes.instanceOf(Date),
-  slotEnd: PropTypes.instanceOf(Date),
-
-  selected: PropTypes.bool,
-  eventPropGetter: PropTypes.func,
-  titleAccessor: accessor,
   allDayAccessor: accessor,
-  startAccessor: accessor,
   endAccessor: accessor,
-
+  event: PropTypes.object.isRequired,
   eventComponent: elementType,
+  eventPropGetter: PropTypes.func,
   eventWrapperComponent: elementType.isRequired,
-  onSelect: PropTypes.func,
   onDoubleClick: PropTypes.func,
   onInlineEditEventTitle: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
+  selected: PropTypes.bool,
+  slotEnd: PropTypes.instanceOf(Date),
+  slotStart: PropTypes.instanceOf(Date),
+  startAccessor: accessor,
+  titleAccessor: accessor,
 };
 
 const StyledEvent = styled.div`
@@ -101,7 +98,6 @@ class EventCell extends React.Component {
       onDoubleClick,
       onInlineEditEventTitle,
       onSelect,
-      resizable,
       selected,
       slotEnd,
       slotStart,
@@ -119,10 +115,6 @@ class EventCell extends React.Component {
 
     if (eventPropGetter)
       var { style, className: xClassName } = eventPropGetter(event, start, end, selected);
-
-    if (resizable) {
-      Event = ResizableMonthEvent;
-    }
 
     return (
       <EventWrapper event={event}>

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -9,6 +9,7 @@ import dates from './utils/dates';
 import { accessor, elementType } from './utils/propTypes';
 import { accessor as get } from './utils/accessors';
 import ResizableMonthEvent from './addons/dragAndDrop/ResizableMonthEvent';
+import { RIGHT_CLICK_EVENT } from './ContextMenuTypes';
 
 let propTypes = {
   event: PropTypes.object.isRequired,
@@ -130,7 +131,7 @@ class EventCell extends React.Component {
           <ContextMenuTrigger
             collect={props => ({ ...props, event })}
             holdToDisplay={-1}
-            id="rightClickEventContextMenu"
+            id={RIGHT_CLICK_EVENT}
           >
             <div
               tabIndex="-1"
@@ -149,7 +150,8 @@ class EventCell extends React.Component {
                   if (!currentTarget.contains(document.activeElement)) {
                     onSelect({}, e);
                   }
-                });
+                  // 100ms is given to setTimeout so that it fires after a right-click event - AR Tue Oct 24 14:10:25 EDT 2017
+                }, 100);
               }}
               onClick={e => onSelect(event, e)}
               /*onDoubleClick={e => onDoubleClick(event, e)}*/

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -61,7 +61,6 @@ export default {
         onDoubleClick={onDoubleClick}
         onInlineEditEventTitle={onInlineEditEventTitle}
         onSelect={onSelect}
-        resizable={props.resizable}
         selected={isSelected(event, selected)}
         slotEnd={end}
         slotStart={start}

--- a/src/Month.js
+++ b/src/Month.js
@@ -205,7 +205,6 @@ class MonthView extends React.Component {
         ref={weekIdx === 0 ? 'slotRow' : undefined}
         renderForMeasure={needLimitMeasure}
         renderHeader={this.readerDateHeading}
-        resizable={this.props.resizable}
         selectable={selectable}
         selected={selected}
         startAccessor={startAccessor}

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -84,7 +84,6 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
     onEventDrop: PropTypes.func.isRequired,
     onEventResize: PropTypes.func,
     onOutsideEventDrop: PropTypes.func,
-    resizable: PropTypes.bool,
     startAccessor: accessor,
   };
 

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -18,16 +18,16 @@ try {
 export default function withDragAndDrop(Calendar, { backend = html5Backend } = {}) {
   class DragAndDropCalendar extends React.Component {
     static propTypes = {
-      selectable: PropTypes.oneOf([true, false, 'ignoreEvents']).isRequired,
       components: PropTypes.object,
+      selectable: PropTypes.oneOf([true, false, 'ignoreEvents']).isRequired,
     };
     getChildContext() {
       return {
+        endAccessor: this.props.endAccessor,
         onEventDrop: this.props.onEventDrop,
         onEventResize: this.props.onEventResize,
         onOutsideEventDrop: this.props.onOutsideEventDrop,
         startAccessor: this.props.startAccessor,
-        endAccessor: this.props.endAccessor,
       };
     }
 
@@ -64,17 +64,15 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
 
       props.selectable = selectable ? 'ignoreEvents' : false;
 
-      props.className = cn(
-        props.className,
-        'rbc-addons-dnd',
-        this.state.isDragging && 'rbc-addons-dnd-is-dragging',
-      );
+      props.className = cn(props.className, 'rbc-addons-dnd', {
+        'rbc-addons-dnd-is-dragging': this.state.isDragging,
+      });
 
       props.components = {
         ...components,
-        eventWrapper: DraggableEventWrapper,
         dateCellWrapper: DateCellWrapper,
         dayWrapper: DayWrapper,
+        eventWrapper: DraggableEventWrapper,
       };
 
       return <Calendar {...props} />;
@@ -91,8 +89,8 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
   };
 
   DragAndDropCalendar.defaultProps = {
-    startAccessor: 'start',
     endAccessor: 'end',
+    startAccessor: 'start',
   };
 
   DragAndDropCalendar.contextTypes = {


### PR DESCRIPTION
## Description
This PR abstracts away components for ContextMenu and ResizableMonthEvent. The reason for this is so that itv-calendar itself has the control over what gets rendered and not react-big-calendar. This will make it easier to make changes to these components in the future instead of having to come back here and make those changes to the component. Ideally, we really should only be making changes to the functionality of the calendar and not how something looks. That should instead all be within itv-calendar.