### PR TITLE
Fix vertical order

### DIFF
--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -99,7 +99,7 @@ class Dnd extends React.Component {
 
   eventsSorter = ({ weight: a }, { weight: b }) => (a < b ? -1 : 1);
 
-  handleEventReorder = (a, b) => {
+  handleEventReorder = (a, b, _idxa, _idxb, list) => {
     let { events } = this.state;
 
     const idxa = events.indexOf(a);
@@ -108,8 +108,9 @@ class Dnd extends React.Component {
     (a = events[idxa]), (b = events[idxb]);
 
     const skew = a.weight > b.weight ? -1 : 1;
-
-    a.weight = b.weight + skew;
+    let remainder = Math.ceil(b.weight / 100) * 100 - b.weight;
+    remainder = remainder <= 0 ? 100 : remainder;
+    a.weight = b.weight + remainder / 2 * skew;
 
     events[idxa] = a;
     this.setState({ events });

--- a/examples/events.js
+++ b/examples/events.js
@@ -24,6 +24,13 @@ export default [
     weight: 200,
   },
   {
+    title: 'All Day Event',
+    allDay: true,
+    start: new Date(2015, 3, 7),
+    end: new Date(2015, 3, 10),
+    weight: 200,
+  },
+  {
     title: 'DTS STARTS',
     start: new Date(2016, 2, 13, 0, 0, 0),
     end: new Date(2016, 2, 20, 0, 0, 0),
@@ -39,7 +46,13 @@ export default [
     title: 'Some Event',
     start: new Date(2015, 3, 9, 0, 0, 0),
     end: new Date(2015, 3, 9, 0, 0, 0),
-    weight: 500,
+    weight: 100,
+  },
+  {
+    title: 'Some Event 2',
+    start: new Date(2015, 3, 9, 0, 0, 0),
+    end: new Date(2015, 3, 9, 0, 0, 0),
+    weight: 200,
   },
   {
     title: 'Conference',

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -7,7 +7,7 @@ import { findDOMNode } from 'react-dom';
 
 import dates from './utils/dates';
 import { accessor, elementType } from './utils/propTypes';
-import { segStyle, eventSegments, endOfRange, eventLevels, withLevels } from './utils/eventLevels';
+import { segStyle, eventSegments, endOfRange, eventLevels } from './utils/eventLevels';
 import BackgroundCells from './BackgroundCells';
 import EventRow from './EventRow';
 import EventEndingRow from './EventEndingRow';


### PR DESCRIPTION
When we attempt to reorder segments vertically that have variable length in the same week row we would get bizarre rendering issues and would experience performance issues because segment position was being miscalculated.

The naive reduce algo used introduced a lot of complexity because of `levels`. I was attempting to reduce `levels` to an array of `segments` that only lived in the DayCell I was hovering in. For example:
<img width="421" alt="screen shot 2017-10-27 at 6 09 19 pm" src="https://user-images.githubusercontent.com/7852183/32129889-3d31abb8-bb42-11e7-8f62-aa8801a184b0.png">

If I was hovering over the ninth, the reduced `levels` array would only contain 2 segments. This introduced a lot of edge cases when segments that started on earlier days and overflowed onto the day-cell I was hovering in. To solve this, instead of reducing the `levels` array to a list of segments, I reduced it to a list of `levels` with a single `segment` object... A segment whom's start date matched current date user is hovering over. In the above example the `levels` array would contain 4 objects, 2 actual segments and 2 with `idx: -1` informing us they are just place holders.