### PR TITLE
Resize Event to be Smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "react-contextmenu": "^2.8.0",
     "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
+    "recompose": "^0.26.0",
     "styled-components": "^2.2.1",
     "uncontrollable": "^3.3.1 || ^4.0.0",
     "warning": "^2.0.0"

--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -29,6 +29,10 @@
     opacity: 0.5;
   }
 
+  &.rbc-addons-dnd-is-dragging .rbc-day-bg-wrapper {
+    z-index: 10;
+  }
+
   .rbc-addons-dnd-resizable-month-event {
     position: relative;
     /* user-drag: none; */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,6 +1655,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+
 child-process-promise@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-1.1.0.tgz#131e01a705f15ed4a05d554dd5e032e52612cf30"
@@ -2960,7 +2964,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3436,7 +3440,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.1.0:
+hoist-non-react-statics@^2.1.0, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -6204,6 +6208,15 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    symbol-observable "^1.0.4"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -6977,7 +6990,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.3:
+symbol-observable@^1.0.1, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 


### PR DESCRIPTION
## Description
This PR fixes the issue where a user would have to "find" a place to drop an event when resizing it. Now the user can just drop the event on any day cell and it will resize.

## Screenshots

![resize-smaller](https://user-images.githubusercontent.com/9747933/32196872-212b8128-bd90-11e7-83a6-a06a24a5bf58.gif)
