### PR TITLE
Declare hover event as type hover

### DIFF
--- a/src/addons/dragAndDrop/backgroundWrapper.js
+++ b/src/addons/dragAndDrop/backgroundWrapper.js
@@ -200,10 +200,10 @@ function createWrapper(type) {
         if (itemType === ItemTypes.RESIZE) {
           switch (eventType) {
             case 'resizeL': {
-              return onEventResize('drop', { event, start: value, end });
+              return onEventResize('hover', { event, start: value, end });
             }
             case 'resizeR': {
-              return onEventResize('drop', { event, start, end: value });
+              return onEventResize('hover', { event, start, end: value });
             }
             default: {
               return;


### PR DESCRIPTION
## Description
I overlooked this when I copy/pasted some code. The eventType should be hover and not drop.