### PR TITLE
Fix inline edit bug

### DIFF
--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -50,9 +50,12 @@ class EventCell extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { event, titleAccessor } = this.props;
-    const { event: nextEvent } = nextProps;
-    const [eventTitle, nextEventTitle] = [get(event, titleAccessor), get(nextEvent, titleAccessor)];
+    const { event: { data: currentEvent }, titleAccessor } = this.props;
+    const { event: { data: nextEvent } } = nextProps;
+    const [eventTitle, nextEventTitle] = [
+      get(currentEvent, titleAccessor),
+      get(nextEvent, titleAccessor),
+    ];
     if (eventTitle !== nextEventTitle) {
       this.setState({ title: nextEventTitle });
     }


### PR DESCRIPTION
## Description
This PR fixes a bug where when a user clicked to edit an event title inline, it would not show the correct event title but rather a title from another event. This was due to the fact that the state was not updated in `componentWillReceiveProps`.