### PR TITLE
Fix drag and drop from sidebar issues

### DIFF
--- a/src/addons/dragAndDrop/backgroundWrapper.js
+++ b/src/addons/dragAndDrop/backgroundWrapper.js
@@ -154,7 +154,7 @@ function createWrapper(type) {
             start: value,
           });
         } else {
-          return onEventDrop({
+          return onEventDrop('drop', {
             event,
             ...getEventTimes(start, end, value, type),
           });
@@ -208,7 +208,7 @@ function createWrapper(type) {
             }
           }
         } else if (itemType === ItemTypes.EVENT && eventType !== 'outsideEvent') {
-          return onEventDrop({
+          return onEventDrop('hover', {
             event,
             ...getEventTimes(start, end, value, type),
           });


### PR DESCRIPTION
## Description
This PR fixes errors when dnd from sidebar to calendar occurs. It makes more declarative the type of event that occurs when the user is dragging an event on the calendar to make the distinction between a drop and hover event.