### PR TITLE
Revert errors that occurred when reordering from sidebar

### DIFF
--- a/src/addons/dragAndDrop/DateContentRowWrapper.js
+++ b/src/addons/dragAndDrop/DateContentRowWrapper.js
@@ -42,8 +42,10 @@ class DateContentRowWrapper extends Component {
     this.setState({ ...next });
   }
 
-  _posEq = (a, b) =>
-    a.span === b.span && a.left === b.left && a.right === b.right && a.level === b.level;
+  _posEq = (a, b) => {
+    if (!a || !b) return;
+    return a.span === b.span && a.left === b.left && a.right === b.right && a.level === b.level;
+  };
 
   handleSegmentDrag = drag => {
     this.setState({ drag });
@@ -51,6 +53,7 @@ class DateContentRowWrapper extends Component {
 
   handleSegmentHover = (hover, hoverData) => {
     const { drag } = this.state;
+    if (!hover || !hover.left || !drag || !drag.left) return;
     if (this._posEq(drag, hover) || hover.left !== drag.left) return;
 
     const { level: dlevel, left: dleft } = drag;


### PR DESCRIPTION
## Description
This PR fixes errors that occurred when trying to reorder events from the sidebar. This does not effect vertical reordering when events exist in the calendar. This will allow us to continue to push and update to this repo without an hassle.