### PR TITLE
Vertical reorder fixes

### DIFF
--- a/src/EventRow.js
+++ b/src/EventRow.js
@@ -24,7 +24,7 @@ class EventRow extends React.Component {
 
           const event = {
             data,
-            position: { left, right, span, level },
+            position: { left, right, span, level, row: this.props.level },
           };
 
           const content = EventRowMixin.renderEvent(this.props, event);

--- a/src/Month.js
+++ b/src/Month.js
@@ -192,6 +192,7 @@ class MonthView extends React.Component {
         eventPropGetter={eventPropGetter}
         events={events}
         key={weekIdx}
+        level={weekIdx}
         eventWrapperComponent={components.eventWrapper}
         longPressThreshold={longPressThreshold}
         maxRows={rowLimit}

--- a/src/addons/dragAndDrop/DateContentRowWrapper.js
+++ b/src/addons/dragAndDrop/DateContentRowWrapper.js
@@ -71,7 +71,6 @@ class DateContentRowWrapper extends Component {
     )
       return; // ignore non overlapping segs
 
-    console.log('h', hoverItem, dragItem, drag);
     const { levels } = this.state;
     const [nextDrag, nextLevels] = reorderLevels(levels, drag, hoverItem.position);
     setDragItem({ ...nextDrag, row });
@@ -85,7 +84,6 @@ class DateContentRowWrapper extends Component {
     const drag = getDragItem();
 
     const dragSeg = levels[drag.level].find(({ left }) => drag.left === left);
-    console.log('found', dragSeg);
     if (!dragSeg) return;
 
     const events = levels.reduce(

--- a/src/addons/dragAndDrop/DateContentRowWrapper.js
+++ b/src/addons/dragAndDrop/DateContentRowWrapper.js
@@ -7,9 +7,10 @@ import findIndex from 'ramda/src/findIndex';
 import BigCalendar from '../../index';
 import { withLevels } from '../../utils/eventLevels';
 
+const overlaps = (left, right) => ({ left: l, right: r }) => r >= left && right >= l;
+
 class DateContentRowWrapper extends Component {
   state = {
-    drag: null,
     hover: null,
     hoverData: null,
   };
@@ -20,6 +21,7 @@ class DateContentRowWrapper extends Component {
 
   static childContextTypes = {
     onSegmentDrag: PropTypes.func,
+    onSegmentDragEnd: PropTypes.func,
     onSegmentHover: PropTypes.func,
     onSegmentDrop: PropTypes.func,
   };
@@ -27,6 +29,7 @@ class DateContentRowWrapper extends Component {
   getChildContext() {
     return {
       onSegmentDrag: this.handleSegmentDrag,
+      onSegmentDragEnd: this.handleSegmentDragEnd,
       onSegmentHover: this.handleSegmentHover,
       onSegmentDrop: this.handleSegmentDrop,
     };
@@ -42,19 +45,17 @@ class DateContentRowWrapper extends Component {
     this.setState({ ...next });
   }
 
-  _posEq = (a, b) => {
-    if (!a || !b) return;
-    return a.span === b.span && a.left === b.left && a.right === b.right && a.level === b.level;
+  handleSegmentDrag = drag => {
+    window.RBC_DRAG_ITEM = drag;
   };
 
-  handleSegmentDrag = drag => {
-    this.setState({ drag });
+  handleSegmentDragEnd = () => {
+    window.RBC_DRAG_ITEM = null;
   };
 
   handleSegmentHover = (hover, hoverData) => {
-    const { drag } = this.state;
-    if (!hover || !hover.left || !drag || !drag.left) return;
-    if (this._posEq(drag, hover) || hover.left !== drag.left) return;
+    const drag = window.RBC_DRAG_ITEM;
+    if (!drag || !overlaps(drag)(hover)) return;
 
     const { level: dlevel, left: dleft } = drag;
     const { level: hlevel, left: hleft } = hover;

--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -16,7 +16,6 @@ let eventSource = {
     return event;
   },
   endDrag(props, monitor, component) {
-    console.log(props, component);
     if (!component) {
       return;
     }

--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -11,16 +11,26 @@ import BigCalendar from '../../index';
 let eventSource = {
   beginDrag({ event }, monitor, { context }) {
     const { onSegmentDrag } = context;
-    onSegmentDrag(event.position);
+    const { data, position } = event;
+    onSegmentDrag({ ...position, event: data });
     return event;
+  },
+  endDrag(props, monitor, component) {
+    if (!component) {
+      window.RBC_DRAG_ITEM = null;
+      return;
+    }
+    const { onSegmentDragEnd } = component.context;
+    onSegmentDragEnd();
   },
 };
 
 const eventTarget = {
-  hover(_, monitor, { props, decoratedComponentInstance: component }) {
+  hover(props, monitor, { decoratedComponentInstance: component }) {
     const { onSegmentHover } = component.context;
-    const { event: { position, data } } = props;
-    onSegmentHover(position, data);
+    const { event: hoverEvent } = props;
+    const dragEvent = monitor.getItem();
+    onSegmentHover(hoverEvent, dragEvent);
   },
   drop(_, monitor, { props, decoratedComponentInstance: component }) {
     const { onSegmentDrop } = component.context;
@@ -32,6 +42,7 @@ const eventTarget = {
 const contextTypes = {
   onEventReorder: PropTypes.func,
   onSegmentDrag: PropTypes.func,
+  onSegmentDragEnd: PropTypes.func,
   onSegmentDrop: PropTypes.func,
   onSegmentHover: PropTypes.func,
 };

--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -16,8 +16,8 @@ let eventSource = {
     return event;
   },
   endDrag(props, monitor, component) {
+    console.log(props, component);
     if (!component) {
-      window.RBC_DRAG_ITEM = null;
       return;
     }
     const { onSegmentDragEnd } = component.context;

--- a/src/addons/dragAndDrop/eventLevels.js
+++ b/src/addons/dragAndDrop/eventLevels.js
@@ -1,0 +1,203 @@
+import findIndex from 'ramda/src/findIndex';
+import propEq from 'ramda/src/propEq';
+import pathEq from 'ramda/src/pathEq';
+import reduce from 'ramda/src/reduce';
+import reduced from 'ramda/src/reduced';
+
+const findSeg = (level, left) => findIndex(propEq('left', left))(level);
+
+const overlaps = (left, right) => ({ left: l, right: r }) => r >= left && right >= l;
+
+const calcRange = segs =>
+  segs.reduce(
+    (acc, { left, right }) => {
+      let [a, b] = acc;
+      if (!a) a = left;
+      if (!b) b = right;
+      if (left < a) a = left;
+      if (right > b) b = right;
+      return [a, b];
+    },
+    [0, 0],
+  );
+
+const groupOverlapping = (level, { left, right }) =>
+  level.reduce(
+    (acc, seg) => {
+      const isOverlapping = overlaps(left, right)(seg);
+      const [a, b] = acc;
+      isOverlapping ? a.push(seg) : b.push(seg);
+      return acc;
+    },
+    [[], []],
+  );
+
+const segSorter = ({ left: a }, { left: b }) => a - b;
+
+const newPos = ({ left }, span) => ({ left, right: left + span - 1, span });
+
+const newSeg = (seg, nextSeg, event) => ({ ...newPos(nextSeg, seg.span), event });
+
+const copyLevels = lvls => lvls.map(lvl => [].concat(lvl));
+
+const reorderLevels = (levels, dragItem, hoverItem) => {
+  let nextLevels = [];
+  const lvls = copyLevels(levels);
+  const { level: dlevel, left: dleft, right: dright, span: dspan } = dragItem;
+  const { level: hlevel, left: hleft, right: hright, span: hspan } = hoverItem;
+
+  if (lvls.length === 0) {
+    return [dragItem, [[dragItem]]];
+  }
+
+  const dragIdx = findSeg(lvls[dlevel] || [], dleft);
+  const hoverIdx = findSeg(lvls[hlevel] || [], hleft);
+
+  // levels
+  const _drag = [].concat(lvls[dlevel] || []);
+  let _hover = [].concat(lvls[hlevel] || []);
+
+  // dragging from outside the cal
+  if (hoverIdx === -1 && dragIdx === -1) {
+    _drag.push(dragItem);
+    _drag.sort(segSorter);
+    lvls[dlevel] = _drag;
+    return [dragItem, lvls.map(lvl => [].concat(lvl))];
+  }
+
+  // drag
+  const { event: dragData, ...dragSeg } = lvls[dlevel][dragIdx];
+
+  // dragging to an empty cell
+  if (hoverIdx === -1 /*&& dragData === hoverItem.event*/) {
+    _drag.splice(dragIdx, 1);
+    if (dlevel === hlevel) {
+      _hover = _drag;
+    }
+    const nextDragSeg = { ...hoverItem, event: dragData };
+    _hover.push(nextDragSeg);
+    _hover.sort(segSorter);
+    (lvls[dlevel] = _drag), (lvls[hlevel] = _hover);
+    return [nextDragSeg, lvls.map(lvl => [].concat(lvl))];
+  }
+
+  const { event: hoverData, ...hoverSeg } = lvls[hlevel][hoverIdx];
+
+  // remove drag and hover items
+  if (dlevel === hlevel) {
+    _drag.splice(dragIdx, 1);
+    const newHoverIdx = findSeg(_drag, hleft);
+    _drag.splice(newHoverIdx, 1);
+    lvls[dlevel] = [].concat(_drag);
+  } else {
+    _drag.splice(dragIdx, 1), _hover.splice(hoverIdx, 1);
+    (lvls[dlevel] = _drag), (lvls[hlevel] = _hover);
+  }
+
+  if (dragIdx < 0 || hoverIdx < 0) {
+    throw `unable to find ${dragIdx < 0 ? 'drag' : 'hover'} segment`;
+  }
+  // calculated overlapping
+  const [overlapping, notOverlapping] = groupOverlapping(lvls[hlevel], dragSeg);
+  let remainder = null;
+  let processRemainder = false;
+  let nextLevelIdx = 0;
+  for (let i = 0, len = lvls.length; i < len; i++) {
+    let level = [].concat(lvls[i]);
+    let lvlDiff = dlevel - hlevel;
+    if (dlevel === i) {
+      if (dleft !== hleft && hlevel === dlevel) {
+        // noop
+      } else if (hspan > 1 && !overlaps(dleft, dright)(hoverSeg) && hlevel !== dlevel) {
+        // noop
+      } else if (Math.abs(lvlDiff) > 1) {
+        // noop
+      } else if (hspan > 1) {
+        const [over, notOver] = groupOverlapping(level, hoverSeg);
+        level = [...notOver, { ...hoverSeg, event: hoverData }];
+        remainder = over.length ? over : null;
+      } else if (dspan > 1) {
+        level.push(...overlapping, { ...hoverSeg, event: hoverData });
+      } else if (dleft !== hleft) {
+        // noop
+      } else if (/*dlevel < hlevel &&*/ Math.abs(lvlDiff) === 1) {
+        // insert hover into current level
+        level.push({ ...hoverSeg, event: hoverData });
+      }
+    }
+
+    if (hlevel === i) {
+      if (dspan > 1) {
+        nextLevelIdx = i;
+        level = [...notOverlapping, { ...dragSeg, event: dragData }];
+      } else if (/*dleft !== hleft*/ !overlaps(dleft, dright)(hoverSeg)) {
+        let leftOffset = hspan !== dspan ? (dleft > hleft ? hright : hleft) - (dspan - 1) : hleft;
+        const nextSeg = newSeg(dragSeg, { left: leftOffset }, dragData);
+        nextLevelIdx = i;
+        level.push(nextSeg);
+        remainder = [{ ...hoverSeg, event: hoverData }];
+      } else if (Math.abs(lvlDiff) === 1) {
+        // insert drag into currect level
+        nextLevelIdx = i;
+        /*hlevel > dlevel &&*/ level.push({ ...dragSeg, event: dragData });
+      } else {
+        if (dlevel < hlevel) {
+          nextLevelIdx = i + 1;
+          nextLevels.push([{ ...hoverSeg, event: hoverData }]);
+          level.push(newSeg(dragSeg, hoverSeg, dragData));
+        } else {
+          nextLevelIdx = i;
+          nextLevels.push([{ ...dragSeg, event: dragData }]);
+          level.push(newSeg(hoverSeg, dragSeg, hoverData));
+        }
+      }
+    }
+
+    if (level.length === 0) continue;
+
+    if (remainder) {
+      if (processRemainder) {
+        const [left, right] = calcRange(remainder);
+        const [over, notOver] = groupOverlapping(level, { left, right });
+        level = [...notOver, ...remainder];
+        //processRemainder = false;
+        remainder = over.length ? over : ((processRemainder = false), null);
+      } else {
+        processRemainder = true;
+      }
+    }
+
+    level.sort(segSorter);
+    nextLevels.push(level);
+  }
+
+  if (remainder) {
+    // detect if we can insert it in last level
+    const [left, right] = calcRange(remainder);
+    const lastLvl = nextLevels[nextLevels.length - 1];
+    const [over, notOver] = groupOverlapping(lastLvl, { left, right });
+    if (over.length) {
+      nextLevels.push(remainder);
+    } else {
+      lastLvl.push(...remainder);
+      lastLvl.sort(segSorter);
+    }
+  }
+
+  // update level prop
+  for (let i = 0, len = nextLevels.length; i < len; i++) {
+    nextLevels[i] = nextLevels[i].map(seg => ({ ...seg, level: i }));
+  }
+
+  // find drag seg
+  return reduce(
+    (acc, level) => {
+      const idx = findIndex(pathEq(['event', 'id'], dragData.id))(level);
+      return idx < 0 ? acc : reduced([level[idx], nextLevels]);
+    },
+    [dragItem, levels],
+    nextLevels,
+  );
+};
+
+export { reorderLevels as default };

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -31,6 +31,10 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
         onEventReorder: this.props.onEventReorder,
         onOutsideEventDrop: this.props.onOutsideEventDrop,
         startAccessor: this.props.startAccessor,
+
+        // accessors for global drag item state
+        setDragItem: drag => this.setState({ drag }),
+        getDragItem: () => this.state.drag,
       };
     }
 
@@ -116,6 +120,8 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
     onEventReorder: PropTypes.func,
     onOutsideEventDrop: PropTypes.func,
     startAccessor: accessor,
+    getDragItem: PropTypes.func,
+    setDragItem: PropTypes.func,
   };
 
   if (backend === false) {


### PR DESCRIPTION
This introduces main logic for vertical + horizontal reorder. However since a few issues persist regarding reordering between days and weeks we are restricting reorder to the day we start dragging from. If we drag into another day, this action will reset vertical reorder and not allow reordering until the item is dropped.