### PR TITLE
Fix ability to select event name when editing inline

### DIFF
--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -9,7 +9,7 @@ import BigCalendar from '../../index';
 /* drag sources */
 
 let eventSource = {
-  beginDrag({ event }, monitor, { context }) {
+  beginDrag({ event, ...props }, monitor, { context }) {
     const { onSegmentDrag } = context;
     const { data, position } = event;
     onSegmentDrag({ ...position, event: data });
@@ -21,6 +21,10 @@ let eventSource = {
     }
     const { onSegmentDragEnd } = component.context;
     onSegmentDragEnd();
+  },
+  canDrag(props, monitor) {
+    const { children: { _owner: { _instance: { state: { isEditingEventTitle } } } } } = props;
+    return !isEditingEventTitle;
   },
 };
 

--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -9,7 +9,7 @@ import BigCalendar from '../../index';
 /* drag sources */
 
 let eventSource = {
-  beginDrag({ event, ...props }, monitor, { context }) {
+  beginDrag({ event }, monitor, { context }) {
     const { onSegmentDrag } = context;
     const { data, position } = event;
     onSegmentDrag({ ...position, event: data });


### PR DESCRIPTION
## Description
This PR fixes the bug that did not allow the user to select the event name when editing inline.

## Screenshots

<a href="https://cl.ly/3W0l2F2R240P" target="_blank"><img src="https://d1ax1i5f2y3x71.cloudfront.net/items/2M3m0d230S173F0m1h1l/Screen%20Recording%202017-11-30%20at%2009.24%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>

## Issues
https://github.com/citrusbyte/itv-calendar/issues/187