### PR TITLE
Fix inline select event name

### DIFF
--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { DragSource, DropTarget } from 'react-dnd';
 import cn from 'classnames';
 import { compose } from 'recompose';
+import { path } from 'ramda';
 
 import BigCalendar from '../../index';
 
@@ -23,8 +24,15 @@ let eventSource = {
     onSegmentDragEnd();
   },
   canDrag(props, monitor) {
-    const { children: { _owner: { _instance: { state: { isEditingEventTitle } } } } } = props;
-    return !isEditingEventTitle;
+    /*
+    itv-calendar uses React 16, meaning that the path to the isEditingEventTitle value in state is different than in React 15.
+    So although isEditing path does not work with the dnd example locally it will work when integrated with itv-calendar. AR - 2017-11-30
+    */
+    const isEditing = path(
+      ['children', '_owner', 'stateNode', 'state', 'isEditingEventTitle'],
+      props,
+    );
+    return !isEditing;
   },
 };
 


### PR DESCRIPTION
## Description
This PR fixes the inline select event name bug for real this time. I should have done an integration test to make sure the previous PR was working properly. I found out that the path to a component's state is different in React 16 so that is why the previous solution did not work. And now `citrusbyte-calendar` needs to be aware of these differences which is unfortunate.