### PR TITLE
Deselect event when background cell is selected

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -156,6 +156,9 @@ class BackgroundCells extends React.Component {
             endIdx: currentCell,
             action: 'click',
           });
+
+          // Deselect event if a background cell is selected
+          this.props.onSelectEvent({});
         }
       }
 

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -159,6 +159,8 @@ class DateContentRow extends React.Component {
       ...props
     } = this.props;
 
+    const onSelectEvent = this.props.onSelect;
+
     if (renderForMeasure) return this.renderDummy();
 
     const { levels, first, last, extra } = this.props;
@@ -171,6 +173,7 @@ class DateContentRow extends React.Component {
           range={range}
           selectable={selectable}
           container={this.getContainer}
+          onSelectEvent={onSelectEvent}
           onSelectStart={onSelectStart}
           onSelectEnd={onSelectEnd}
           onSelectSlot={this.handleSelectSlot}


### PR DESCRIPTION
## Description
This PR is a quick fix to deselect an event when a background cell is selected. There was an attempt in the past to handle this with `onBlur` but that did not work as expected because the bubbling of events made it difficult to implement. This is a quick fix to deselect an event when a background cell is selected.