### PR TITLE
Pass down handler for event drop side-effects

### DIFF
--- a/src/addons/dragAndDrop/DraggableEventWrapper.js
+++ b/src/addons/dragAndDrop/DraggableEventWrapper.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import cn from 'classnames';
 import { compose } from 'recompose';
-import { path } from 'ramda';
+import { path, pathEq } from 'ramda';
 
 import BigCalendar from '../../index';
 
@@ -65,20 +65,27 @@ const eventTarget = {
     onSegmentHover(hoverEvent, dragEvent);
   },
   drop(_, monitor, { props, decoratedComponentInstance: component }) {
-    const { onSegmentDrop } = component.context;
-    const { position } = monitor.getItem();
+    const item = monitor.getItem();
+    const { position } = item;
+    const { onSegmentDrop, onOutsideEventOrderAndDrop } = component.context;
+
+    if (pathEq(['type'], 'outsideEvent', item)) {
+      onOutsideEventOrderAndDrop(item.data);
+    }
+
     onSegmentDrop(position);
   },
 };
 
 const contextTypes = {
+  getInternalState: PropTypes.func,
   onEventReorder: PropTypes.func,
+  onOutsideEventOrderAndDrop: PropTypes.func,
   onSegmentDrag: PropTypes.func,
   onSegmentDragEnd: PropTypes.func,
   onSegmentDrop: PropTypes.func,
   onSegmentHover: PropTypes.func,
   setInternalState: PropTypes.func,
-  getInternalState: PropTypes.func,
 };
 
 const propTypes = {

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -41,9 +41,10 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
       return {
         endAccessor: this.props.endAccessor,
         onEventDrop: this.props.onEventDrop,
-        onEventResize: this.props.onEventResize,
         onEventReorder: this.props.onEventReorder,
+        onEventResize: this.props.onEventResize,
         onOutsideEventDrop: this.props.onOutsideEventDrop,
+        onOutsideEventOrderAndDrop: this.props.onOutsideEventOrderAndDrop,
         startAccessor: this.props.startAccessor,
 
         // accessors for global drag item state
@@ -107,6 +108,7 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
       delete props.onEventResize;
       delete props.onEventReorder;
       delete props.onOutsideEventDrop;
+      delete props.onOutsideEventOrderAndDrop;
 
       props.selectable = selectable ? 'ignoreEvents' : false;
 
@@ -149,14 +151,15 @@ export default function withDragAndDrop(Calendar, { backend = html5Backend } = {
 
   DragAndDropCalendar.childContextTypes = {
     endAccessor: accessor,
-    onEventUpdate: PropTypes.func,
-    onEventDrop: PropTypes.func,
-    onEventResize: PropTypes.func,
-    onEventReorder: PropTypes.func,
-    onOutsideEventDrop: PropTypes.func,
-    startAccessor: accessor,
     getInternalState: PropTypes.func,
+    onEventDrop: PropTypes.func,
+    onEventReorder: PropTypes.func,
+    onEventResize: PropTypes.func,
+    onEventUpdate: PropTypes.func,
+    onOutsideEventDrop: PropTypes.func,
+    onOutsideEventOrderAndDrop: PropTypes.func,
     setInternalState: PropTypes.func,
+    startAccessor: accessor,
   };
 
   if (backend === false) {


### PR DESCRIPTION
## Description

This PR adds the `onOutsideEventOrderAndDrop` function to the `DraggableEventWrapper` in order to perform a side-effect after dropping an `outsideEvent` on the calendar. This is specifically to update parent categories visibility in itv-calendar.